### PR TITLE
Add support for multiple Examples in Scenario Outline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ pub struct Scenario {
     pub steps: Vec<Step>,
     // The parsed examples from the scenario directive if found.
     #[cfg_attr(feature = "parser", builder(default))]
-    pub examples: Option<Examples>,
+    pub examples: Vec<Examples>,
     /// The tags for the scenarios directive if provided.
     #[cfg_attr(feature = "parser", builder(default))]
     pub tags: Vec<String>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -383,7 +383,7 @@ rule scenario() -> Scenario
       pa:position!()
       k:keyword((env.keywords().scenario)) ":" _ n:not_nl() _ nl_eof()
       s:steps()?
-      e:examples()?
+      e:examples()*
       pb:position!()
     {
         Scenario::builder()
@@ -403,7 +403,7 @@ rule scenario() -> Scenario
       pa:position!()
       k:keyword((env.keywords().scenario_outline)) ":" _ n:not_nl() _ nl_eof()
       s:steps()?
-      e:examples()?
+      e:examples()*
       pb:position!()
     {
         Scenario::builder()

--- a/tests/test.feature
+++ b/tests/test.feature
@@ -41,6 +41,23 @@ Scenario Outline: eating
     |    12 |   5 |    7 |
     |    20 |   5 |   15 |
 
+@multiple-examples
+Scenario Outline: eating
+  Given there are <start> cucumbers
+  When I eat <eat> cucumbers
+  Then I should have <left> cucumbers
+
+  Examples:
+    | start | eat | left |
+    |    12 |   5 |    7 |
+    |    20 |   5 |   15 |
+
+  @another-misfeature-of-cucumber
+  Examples:
+    | start | eat | left |
+    |    12 |   5 |    7 |
+    |    20 |   5 |   15 |
+
 @scenario-with-tab-indentation
 Scenario: A second scenario test
 # Below are TABs don't remove/convert them


### PR DESCRIPTION
Revealed in https://github.com/cucumber-rs/cucumber/issues/164

This feature is even described in [test features](https://github.com/bbqsrc/gherkin-rust/blob/main/tests/fixtures/data/good/several_examples.feature)