### PR TITLE
Fix supported characters in Tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 
 
 
+## [0.11.1] · ???
+[0.11.1]: /../../tree/v0.11.1
+
+[Diff](/../../compare/v0.11.0...v0.11.1)
+
+### Fixed
+
+- Allowed keywords in `Feature`s `Description`. ([#30], [cucumber#175])
+- Allowed characters in `Tag`s. ([#30], [cucumber#174])
+- Comments on the same line with `Tag`s. ([#30])
+  
+[#30]: /../../pull/30
+[cucumber#174]: https://github.com/cucumber-rs/cucumber/issues/174
+[cucumber#175]: https://github.com/cucumber-rs/cucumber/issues/175
+
+
+
+
 ## [0.11.0] · 2021-12-06
 [0.11.0]: /../../tree/v0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 - Allowed keywords in `Feature`s `Description`. ([#30], [cucumber#175])
 - Allowed characters in `Tag`s. ([#30], [cucumber#174])
 - Comments on the same line with `Tag`s. ([#30])
-  
+- `Tag`s requiring whitespaces between them. ([#30]) 
+
 [#30]: /../../pull/30
 [cucumber#174]: https://github.com/cucumber-rs/cucumber/issues/174
 [cucumber#175]: https://github.com/cucumber-rs/cucumber/issues/175

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 
 
 
-## [0.11.1] · ???
+## [0.11.1] · 2021-12-??
 [0.11.1]: /../../tree/v0.11.1
 
 [Diff](/../../compare/v0.11.0...v0.11.1)
@@ -16,11 +16,13 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 - Allowed keywords in `Feature`s `Description`. ([#30], [cucumber#175])
 - Allowed characters in `Tag`s. ([#30], [cucumber#174])
 - Comments on the same line with `Tag`s. ([#30])
-- `Tag`s requiring whitespaces between them. ([#30]) 
+- `Tag`s requiring whitespaces between them. ([#30])
+- [Escaping][0111-1] in `TagOperation`. ([#30])
 
 [#30]: /../../pull/30
 [cucumber#174]: https://github.com/cucumber-rs/cucumber/issues/174
 [cucumber#175]: https://github.com/cucumber-rs/cucumber/issues/175
+[0111-1]: https://github.com/cucumber/tag-expressions/tree/6f444830b23bd8e0c5a2617cd51b91bc2e05adde#escaping
 
 
 

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::ops::Deref;
+
 #[derive(Debug, Clone)]
 pub(crate) struct Keywords<'a> {
     pub feature: &'a [&'a str],
@@ -36,14 +38,11 @@ impl<'a> Keywords<'a> {
     }
 
     pub fn all(&self) -> Vec<&'a str> {
-        let mut v = vec![];
-
-        for x in [
+        let mut v = [
             self.feature,
             self.background,
             self.rule,
             self.scenario,
-            self.rule,
             self.scenario_outline,
             self.examples,
             self.given,
@@ -53,9 +52,26 @@ impl<'a> Keywords<'a> {
             self.but,
         ]
         .iter()
-        {
-            v.append(&mut x.to_vec());
-        }
+        .flat_map(|s| s.iter().map(Deref::deref))
+        .collect::<Vec<_>>();
+
+        v.sort_unstable();
+
+        v
+    }
+
+    pub fn exclude_in_description(&self) -> Vec<&'a str> {
+        let mut v = [
+            self.feature,
+            self.background,
+            self.rule,
+            self.scenario,
+            self.scenario_outline,
+            self.examples,
+        ]
+        .iter()
+        .flat_map(|s| s.iter().map(Deref::deref))
+        .collect::<Vec<_>>();
 
         v.sort_unstable();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -421,7 +421,7 @@ rule tag_char() -> &'input str
     = s:$([_]) {?
         let x = s.chars().next().unwrap();
         // `)` isn't allowed, as it would collide with TagExpression.
-        if !x.is_whitespace() && !"\n@)".contains(x) {
+        if !x.is_whitespace() && !"\r\n@)".contains(x) {
             Ok(s)
         } else {
             Err("tag character")

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -415,7 +415,7 @@ rule scenario() -> Scenario
 rule tag_char() -> &'input str
     = s:$([_]) {?
         let x = s.chars().next().unwrap();
-        if x.is_alphanumeric() || x == '_' || x == '-' {
+        if x.is_alphanumeric() || "_-.#".contains(x) {
             Ok(s)
         } else {
             Err("tag character")

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -426,7 +426,7 @@ pub(crate) rule tag() -> String
     = "@" s:tag_char()+ { s.join("") }
 
 pub(crate) rule tags() -> Vec<String>
-    = t:(tag() ** ([' ']+)) _ nl() { t }
+    = t:(tag() ** _) _ nl() { t }
     / { vec![] }
 
 rule rule_() -> Rule

--- a/src/tagexpr.rs
+++ b/src/tagexpr.rs
@@ -113,4 +113,34 @@ mod tests {
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
     }
+
+    #[test]
+    fn parse_tag_expr9() {
+        let foo: TagOperation = "@bar\\\\\\)\\ \\("
+            .parse()
+            .unwrap_or_else(|e| panic!("{}", e));
+        println!("{:#?}", foo);
+    }
+
+    #[test]
+    fn parse_tag_expr10() {
+        let foo: TagOperation = "(@foo and @bar\\))"
+            .parse()
+            .unwrap_or_else(|e| panic!("{}", e));
+        println!("{:#?}", foo);
+    }
+
+    #[test]
+    fn parse_tag_expr11() {
+        let foo: TagOperation = "not (@\\)a or @\\(b) and (@c or not @d)"
+            .parse()
+            .unwrap_or_else(|e| panic!("{}", e));
+        println!("{:#?}", foo);
+    }
+
+    #[test]
+    fn parse_tag_expr12() {
+        let err = "@bar\\".parse::<TagOperation>().unwrap_err();
+        println!("{:#?}", err);
+    }
 }

--- a/tests/test.feature
+++ b/tests/test.feature
@@ -19,7 +19,7 @@ Background:
   And then it was fun
     | value1 | value2 |
 
-@tag1 @tag2 @tag-life_woo
+@tag1 @tag2 @tag-life_woo @tag.with#more.chars
 Scenario: A second scenario test
   Given I have not been testing much
   Then I should probably start doing it
@@ -29,7 +29,7 @@ Scenario: A second scenario test
     Given I am lightly tabbed
     Then handle how tabbed I am
 
-@taglife
+@taglife@with_joined_tags
 Scenario Outline: eating
   Given there are <start> cucumbers
   When I eat <eat> cucumbers

--- a/tests/test.feature
+++ b/tests/test.feature
@@ -2,6 +2,11 @@
 @feature-tag
 Feature: This is a feature file
 
+  For all queries, parameters will not be set for default values as defined by:
+  * Numeric inputs: 0
+  * String inputs: ""
+  But list isn't exhaustive
+
 
 # Surprise comment
 Background:
@@ -19,7 +24,11 @@ Background:
   And then it was fun
     | value1 | value2 |
 
-@tag1 @tag2 @tag-life_woo @tag.with#more.chars
+#comment
+@tag1 @tag2 @tag-life_woo @tag.with#more.chars #comment
+
+
+#comment
 Scenario: A second scenario test
   Given I have not been testing much
   Then I should probably start doing it
@@ -30,7 +39,7 @@ Scenario: A second scenario test
     Then handle how tabbed I am
 
 @taglife@with_joined_tags
-Scenario Outline: eating
+Scenario Outline: eating <eat> cucumbers
   Given there are <start> cucumbers
   When I eat <eat> cucumbers
   Then I should have <left> cucumbers


### PR DESCRIPTION
Resolves https://github.com/cucumber-rs/cucumber/issues/174, https://github.com/cucumber-rs/cucumber/issues/175

## Synopsis

Despite nowhere to be documented, it looks like `.` can be present in `Tag`s.



## Solution

Support any non-whitespace character, excluding `@` and `)`, as seen [here](https://github.com/cucumber/common/blob/main/gherkin/testdata/good/tags.feature#L31).




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
