### PR TITLE
Allow text after Background: and Examples:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 
 ### Added
 
-- Support for text after `Background` and `Examples` ([#32])
+- Support text after `Background` and `Examples` keywords. ([#32])
 
 [#32]: /../../pull/32
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 
 
 
+## [0.12.0] · 2022-??-??
+[0.12.0]: /../../tree/v0.12.0
+
+[Diff](/../../compare/v0.11.1...v0.12.0)
+
+### Added
+
+- Support for text after `Background` and `Examples` ([#32])
+
+[#32]: /../../pull/32
+
+
+
+
 ## [0.11.1] · 2021-12-08
 [0.11.1]: /../../tree/v0.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 
 ### Added
 
-- Support text after `Background` and `Examples` keywords. ([#32])
+- Support text after `Background` and `Examples` keywords. ([#31])
 
-[#32]: /../../pull/32
+[#32]: /../../pull/31
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,11 @@ syn = "1.0"
 
 [dev-dependencies]
 async-trait = "0.1.40"
-cucumber = "0.10"
+cucumber = "0.11"
 futures = "0.3.5"
+
+[patch.crates-io]
+gherkin = { path = "." }
 
 [[test]]
 name = "cucumber"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ syn = "1.0"
 
 [dev-dependencies]
 async-trait = "0.1.40"
-cucumber = "0.11"
+cucumber = "0.10"
 futures = "0.3.5"
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,6 @@ async-trait = "0.1.40"
 cucumber = "0.11"
 futures = "0.3.5"
 
-[patch.crates-io]
-gherkin = { path = "." }
-
 [[test]]
 name = "cucumber"
 harness = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,8 @@ impl LineCol {
 pub struct Background {
     /// The raw keyword used in the original source.
     pub keyword: String,
+    /// The name of the background.
+    pub name: Option<String>,
     /// The parsed steps from the background directive.
     pub steps: Vec<Step>,
     /// The `(start, end)` offset the background directive was found in the .feature file.
@@ -132,6 +134,8 @@ pub struct Background {
 pub struct Examples {
     /// The raw keyword used in the original source.
     pub keyword: String,
+    /// The name of the examples.
+    pub name: Option<String>,
     /// The data table from the examples directive.
     pub table: Table,
     /// The tags for the examples directive if provided.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -151,6 +151,7 @@ peg::parser! { pub(crate) grammar gherkin_parser(env: &GherkinEnv) for str {
 
 rule _() = quiet!{[' ' | '\t']*}
 rule __() = quiet!{[' ' | '\t']+}
+rule ___() = quiet!{(!nl0()[_])*}
 
 rule nl0() = quiet!{"\r"? "\n"}
 rule nl() = quiet!{nl0() p:position!() comment()* {
@@ -331,7 +332,7 @@ pub(crate) rule steps() -> Vec<Step>
 
 rule background() -> Background
     = comment()* _ pa:position!()
-      k:keyword((env.keywords().background)) ":" _ nl_eof()
+      k:keyword((env.keywords().background)) ":" ___ nl_eof()
       s:steps()?
       pb:position!()
     {
@@ -372,7 +373,7 @@ rule examples() -> Examples
       t:tags()
       _
       pa:position!()
-      k:keyword((env.keywords().examples)) ":" _ nl_eof()
+      k:keyword((env.keywords().examples)) ":" ___ nl_eof()
       tb:table()
       pb:position!()
     {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -117,7 +117,7 @@ impl GherkinEnv {
         let line = line_offsets
             .iter()
             .position(|x| x > &offset)
-            .unwrap_or(line_offsets.len());
+            .unwrap_or_else(|| line_offsets.len());
 
         let col = offset - line_offsets[line - 1] + 1;
 


### PR DESCRIPTION
Currently this crate allows only whitespace after `Background:`, but any characters should be allowed.

From [Gherkin reference](https://cucumber.io/docs/gherkin/reference/)
`Each line that isn’t a blank line has to start with a Gherkin keyword, followed by any text you like.` I have also checked online the [the official JS implementation](https://cucumber.github.io/cucumber-js/) and it allows the text after.

VS code extension also puts there some text by default which is how I stumbled upon this.

I have also added the same for `Examples:`, all other keywords seem to have names normally so those should be covered.

One more commit I did was overriding the transitive dependency on this crate in the cucumber test so that it uses this version, not anything in crates.io. I also had to update the cucumber version because of the crate name change.