### PR TITLE
Fix line number reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 ### Added
 
 - Support text after `Background` and `Examples` keywords. ([#31])
+- Fix line number reporting ([#33])
 
-[#32]: /../../pull/31
+[#31]: /../../pull/31
+[#33]: /../../pull/33
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 
 ### Fixed
 
-- Fix line number reporting ([#33])
+- Incorrect line numbers reporting. ([#33])
 
 [#31]: /../../pull/31
 [#33]: /../../pull/33

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 ### Added
 
 - Support text after `Background` and `Examples` keywords. ([#31])
+
+### Fixed
+
 - Fix line number reporting ([#33])
 
 [#31]: /../../pull/31

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -670,9 +670,11 @@ Scenario: Hello
     #[test]
     fn correct_line_number() {
         let env = GherkinEnv::default();
-        let input = r#"Feature: Basic functionality
+        let input = r#"
+# language: en
+Feature: Basic functionality
         here's some text
-        really
+     really
 @tag
 Scenario: Hello
   Given a step
@@ -683,6 +685,7 @@ Scenario: Hello
   
   And more
   
+# comment
 Rule: rule
     @tag
     Scenario Outline: Hello
@@ -699,37 +702,39 @@ Rule: rule
         
     @tag
 Rule: rule
+    #comment
     Scenario: Hello
         Given a step
 "#;
         let feature = gherkin_parser::feature(input, &env).unwrap();
         assert_eq!(feature.scenarios.len(), 2);
         assert!(feature.description.is_some());
-        assert_eq!(feature.position.line, 1);
-        assert_eq!(feature.scenarios[0].position.line, 5);
-        assert_eq!(feature.scenarios[0].steps[0].position.line, 6);
-        assert_eq!(feature.scenarios[0].steps[1].position.line, 7);
-        assert_eq!(feature.scenarios[1].position.line, 9);
-        assert_eq!(feature.scenarios[1].steps[0].position.line, 10);
-        assert_eq!(feature.scenarios[1].steps[1].position.line, 12);
-        assert_eq!(feature.rules[0].position.line, 14);
-        assert_eq!(feature.rules[0].scenarios[0].position.line, 16);
-        assert_eq!(feature.rules[0].scenarios[0].steps[0].position.line, 17);
-        assert_eq!(feature.rules[0].scenarios[0].examples[0].position.line, 22);
+        assert_eq!(feature.position.line, 3);
+        assert_eq!(feature.scenarios[0].position.line, 7);
+        assert_eq!(feature.scenarios[0].steps[0].position.line, 8);
+        assert_eq!(feature.scenarios[0].steps[1].position.line, 9);
+        assert_eq!(feature.scenarios[1].position.line, 11);
+        assert_eq!(feature.scenarios[1].steps[0].position.line, 12);
+        assert_eq!(feature.scenarios[1].steps[1].position.line, 14);
+        assert_eq!(feature.rules[0].position.line, 17);
+        assert_eq!(feature.rules[0].position.line, 17);
+        assert_eq!(feature.rules[0].scenarios[0].position.line, 19);
+        assert_eq!(feature.rules[0].scenarios[0].steps[0].position.line, 20);
+        assert_eq!(feature.rules[0].scenarios[0].examples[0].position.line, 25);
         assert_eq!(
             feature.rules[0].scenarios[0].examples[0]
                 .table
                 .position
                 .line,
-            23,
+            26,
         );
         assert_eq!(
             feature.rules[0].scenarios[0].examples[0].table.rows.len(),
             3,
         );
-        assert_eq!(feature.rules[1].position.line, 29);
-        assert_eq!(feature.rules[1].scenarios[0].position.line, 30);
-        assert_eq!(feature.rules[1].scenarios[0].steps[0].position.line, 31);
+        assert_eq!(feature.rules[1].position.line, 32);
+        assert_eq!(feature.rules[1].scenarios[0].position.line, 34);
+        assert_eq!(feature.rules[1].scenarios[0].steps[0].position.line, 35);
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -111,7 +111,7 @@ impl GherkinEnv {
     fn increment_nl(&self, offset: usize) {
         let mut line_offsets = self.line_offsets.borrow_mut();
         if !line_offsets.contains(&offset) {
-            line_offsets.push(dbg!(offset));
+            line_offsets.push(offset);
         }
     }
 
@@ -120,7 +120,7 @@ impl GherkinEnv {
         let line = line_offsets
             .iter()
             .position(|x| x > &offset)
-            .unwrap_or_else(|| dbg!(line_offsets.len()));
+            .unwrap_or_else(|| line_offsets.len());
 
         let col = offset - line_offsets[line - 1] + 1;
 
@@ -383,7 +383,7 @@ rule examples() -> Examples
             .tags(t)
             .table(tb)
             .span(Span { start: pa, end: pb })
-            .position(env.position(dbg!(pa)))
+            .position(env.position(pa))
             .build()
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -668,7 +668,7 @@ Scenario: Hello
     }
 
     #[test]
-    fn correct_line_number() {
+    fn correct_line_numbers() {
         let env = GherkinEnv::default();
         let input = r#"
 # language: en
@@ -682,9 +682,9 @@ Scenario: Hello
 @tag
 Scenario: Hello
   Given a step
-  
+
   And more
-  
+
 # comment
 Rule: rule
     @tag
@@ -693,13 +693,13 @@ Rule: rule
         """
         Doc String
         """
-        
+
     Examples:
         | step |
-        | 1    | 
+        | 1    |
         | 2    |
-        
-        
+
+
     @tag
 Rule: rule
     #comment


### PR DESCRIPTION
## Synopsis

Currently reported line number may be greater that the actual one. This happens, because `GherkinEnv::line_offsets` may contain duplicates.



## Solution

Check whether value already exists before pushing into `GherkinEnv::line_offsets`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
