### PR TITLE
Fix parsing error on feature with comment and tag (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 
 - Bump up [MSRV] to 1.62 to support newer versions of dependencies.
 
+### Fixed
+
+- Parsing error on `Feature` with comment and tag (#37, #35)
+
+[#35]: /../../issues/35
+[#37]: /../../pull/37
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 
 ### Fixed
 
-- Parsing error on `Feature` with comment and tag (#37, #35)
+- Parsing error on a `Feature` having comment and `Tag` simultaneously. (#37, #35)
 
 [#35]: /../../issues/35
 [#37]: /../../pull/37

--- a/tests/fixtures/data/good/feature_with_comment.feature
+++ b/tests/fixtures/data/good/feature_with_comment.feature
@@ -1,0 +1,2 @@
+#comment
+Feature: feature

--- a/tests/fixtures/data/good/feature_with_comment.feature.ast.ndjson
+++ b/tests/fixtures/data/good/feature_with_comment.feature.ast.ndjson
@@ -1,0 +1,1 @@
+{"gherkinDocument":{"comments":["comment"],"feature":{"children":[],"description":"","keyword":"Feature","language":"en","location":{"column":1,"line":1},"name":"feature","tags":[]},"uri":"testdata/good/feature_with_comment.feature"}}

--- a/tests/fixtures/data/good/feature_with_comment_and_tag.feature
+++ b/tests/fixtures/data/good/feature_with_comment_and_tag.feature
@@ -1,0 +1,3 @@
+#comment
+@tag
+Feature: feature

--- a/tests/fixtures/data/good/feature_with_comment_and_tag.feature.ast.ndjson
+++ b/tests/fixtures/data/good/feature_with_comment_and_tag.feature.ast.ndjson
@@ -1,0 +1,1 @@
+{"gherkinDocument":{"comments":["comment"],"feature":{"children":[],"description":"","keyword":"Feature","language":"en","location":{"column":1,"line":1},"name":"feature","tags":["tag"]},"uri":"testdata/good/feature_with_comment.feature"}}

--- a/tests/fixtures/data/good/feature_with_tag.feature
+++ b/tests/fixtures/data/good/feature_with_tag.feature
@@ -1,0 +1,2 @@
+@tag
+Feature: feature

--- a/tests/fixtures/data/good/feature_with_tag.feature.ast.ndjson
+++ b/tests/fixtures/data/good/feature_with_tag.feature.ast.ndjson
@@ -1,0 +1,1 @@
+{"gherkinDocument":{"comments":[],"feature":{"children":[],"description":"","keyword":"Feature","language":"en","location":{"column":1,"line":1},"name":"feature","tags":["tag"]},"uri":"testdata/good/feature_with_tag.feature"}}


### PR DESCRIPTION
Fixes #35


## Synopsis

Currently parsing fails on:

```gherkin
#comment
@tag
Feature: feature
```



## Solution

The problem is `nl()` rule currently tries to parse newline and then `comment()` rule. It leads to a recursion and possible stack overflow and can't parse file, that begins with a comment. Adding a newline to a beginning of the file removes error.

Parse comment first and then newline. 




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
