### PR TITLE
Fix precendence for tag expression parsing rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 
 
 
+## main
+
+### BC Breaks
+
+- Fixed precedence of operations in tag expressions to align with upstream. ([#52], [#51])
+
+[#51]: https://github.com/cucumber-rs/gherkin/issues/51
+[#52]: https://github.com/cucumber-rs/gherkin/pull/52
+
+
+
+
 ## [0.15.0] · 2025-12-12
 [0.15.0]: https://github.com/cucumber-rs/gherkin/tree/v0.15.0
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -573,12 +573,14 @@ pub(crate) rule feature() -> Feature
     }
 
 pub(crate) rule tag_operation() -> TagOperation = precedence!{
-    x:@ _ "and" _ y:(@) { TagOperation::And(Box::new(x), Box::new(y)) }
-    x:@ _ "or" _ y:(@) { TagOperation::Or(Box::new(x), Box::new(y)) }
+    x:(@) _ "or" _ y:@ { TagOperation::Or(Box::new(x), Box::new(y)) }
+    --
+    x:(@) _ "and" _ y:@ { TagOperation::And(Box::new(x), Box::new(y)) }
+    --
     "not" _ x:(@) { TagOperation::Not(Box::new(x)) }
     --
+    "(" _ t:tag_operation() _ ")" _ { t }
     t:tag_in_expr() { TagOperation::Tag(t) }
-    "(" t:tag_operation() ")" _ { t }
 }
 
 }}

--- a/src/tagexpr.rs
+++ b/src/tagexpr.rs
@@ -93,7 +93,10 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
-        assert_eq!(format!("{foo:?}"), "And(Not(Tag(\"foo\")), Not(Or(Tag(\"haha\"), Tag(\"bar\"))))");
+        assert_eq!(
+            format!("{foo:?}"),
+            "And(Not(Tag(\"foo\")), Not(Or(Tag(\"haha\"), Tag(\"bar\"))))",
+        );
     }
 
     #[test]
@@ -102,7 +105,10 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
-        assert_eq!(format!("{foo:?}"), "Or(And(Not(Tag(\"foo\")), Not(Tag(\"haha\"))), Tag(\"bar\"))");
+        assert_eq!(
+            format!("{foo:?}"),
+            "Or(And(Not(Tag(\"foo\")), Not(Tag(\"haha\"))), Tag(\"bar\"))",
+        );
     }
 
     #[test]
@@ -111,7 +117,10 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
-        assert_eq!(format!("{foo:?}"), "And(Not(Or(Tag(\"a\"), Tag(\"b\"))), Or(Tag(\"c\"), Not(Tag(\"d\"))))");
+        assert_eq!(
+            format!("{foo:?}"),
+            "And(Not(Or(Tag(\"a\"), Tag(\"b\"))), Or(Tag(\"c\"), Not(Tag(\"d\"))))",
+        );
     }
 
     #[test]
@@ -120,7 +129,10 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
-        assert_eq!(format!("{foo:?}"), "Or(Or(Tag(\"a\"), And(Tag(\"b\"), Tag(\"c\"))), Not(Tag(\"d\")))");
+        assert_eq!(
+            format!("{foo:?}"),
+            "Or(Or(Tag(\"a\"), And(Tag(\"b\"), Tag(\"c\"))), Not(Tag(\"d\")))",
+        );
     }
 
     #[test]
@@ -146,7 +158,10 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
-        assert_eq!(format!("{foo:?}"), "And(Not(Or(Tag(\")a\"), Tag(\"(b\"))), Or(Tag(\"c\"), Not(Tag(\"d\"))))");
+        assert_eq!(
+            format!("{foo:?}"),
+            "And(Not(Or(Tag(\")a\"), Tag(\"(b\"))), Or(Tag(\"c\"), Not(Tag(\"d\"))))",
+        );
     }
 
     #[test]
@@ -161,10 +176,13 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
-        let foo2: TagOperation = "( ( ( not ( @a ) or ( @b and not ( @c ) ) ) or not ( @d ) ) or ( @e and @f ) )"
+
+        let foo2: TagOperation = "( ( ( not ( @a ) or ( @b and not ( @c ) ) ) \
+                                  or not ( @d ) ) or ( @e and @f ) )"
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo2);
+
         assert_eq!(format!("{foo:?}"), format!("{foo2:?}"));
     }
 }

--- a/src/tagexpr.rs
+++ b/src/tagexpr.rs
@@ -50,11 +50,13 @@ mod tests {
     fn parse_tag_expr1() {
         let foo: TagOperation = "@foo and @bar".parse().unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
+        assert_eq!(format!("{foo:?}"), "And(Tag(\"foo\"), Tag(\"bar\"))");
     }
     #[test]
     fn parse_tag_expr2() {
         let foo: TagOperation = "@foo or @bar".parse().unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
+        assert_eq!(format!("{foo:?}"), "Or(Tag(\"foo\"), Tag(\"bar\"))");
     }
 
     #[test]
@@ -63,17 +65,20 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
+        assert_eq!(format!("{foo:?}"), "And(Tag(\"foo\"), Tag(\"bar\"))");
     }
     #[test]
     fn parse_tag_expr2b() {
         let foo: TagOperation = "(@foo or @bar)".parse().unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
+        assert_eq!(format!("{foo:?}"), "Or(Tag(\"foo\"), Tag(\"bar\"))");
     }
 
     #[test]
     fn parse_tag_expr3() {
         let foo: TagOperation = "not @fat".parse().unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
+        assert_eq!(format!("{foo:?}"), "Not(Tag(\"fat\"))");
     }
 
     #[test]
@@ -88,6 +93,7 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
+        assert_eq!(format!("{foo:?}"), "And(Not(Tag(\"foo\")), Not(Or(Tag(\"haha\"), Tag(\"bar\"))))");
     }
 
     #[test]
@@ -96,6 +102,7 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
+        assert_eq!(format!("{foo:?}"), "Or(And(Not(Tag(\"foo\")), Not(Tag(\"haha\"))), Tag(\"bar\"))");
     }
 
     #[test]
@@ -104,6 +111,7 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
+        assert_eq!(format!("{foo:?}"), "And(Not(Or(Tag(\"a\"), Tag(\"b\"))), Or(Tag(\"c\"), Not(Tag(\"d\"))))");
     }
 
     #[test]
@@ -112,6 +120,7 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
+        assert_eq!(format!("{foo:?}"), "Or(Or(Tag(\"a\"), And(Tag(\"b\"), Tag(\"c\"))), Not(Tag(\"d\")))");
     }
 
     #[test]
@@ -120,6 +129,7 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
+        assert_eq!(format!("{foo:?}"), "Tag(\"bar\\\\) (\")");
     }
 
     #[test]
@@ -136,11 +146,25 @@ mod tests {
             .parse()
             .unwrap_or_else(|e| panic!("{}", e));
         println!("{:#?}", foo);
+        assert_eq!(format!("{foo:?}"), "And(Not(Or(Tag(\")a\"), Tag(\"(b\"))), Or(Tag(\"c\"), Not(Tag(\"d\"))))");
     }
 
     #[test]
     fn parse_tag_expr12() {
         let err = "@bar\\".parse::<TagOperation>().unwrap_err();
         println!("{:#?}", err);
+    }
+
+    #[test]
+    fn parse_tag_expr13() {
+        let foo: TagOperation = "not @a or @b and not @c or not @d or @e and @f"
+            .parse()
+            .unwrap_or_else(|e| panic!("{}", e));
+        println!("{:#?}", foo);
+        let foo2: TagOperation = "( ( ( not ( @a ) or ( @b and not ( @c ) ) ) or not ( @d ) ) or ( @e and @f ) )"
+            .parse()
+            .unwrap_or_else(|e| panic!("{}", e));
+        println!("{:#?}", foo2);
+        assert_eq!(format!("{foo:?}"), format!("{foo2:?}"));
     }
 }


### PR DESCRIPTION
Tag expressions in Gherkin should follow the usual precedence and associativity rules of boolean expressions (see e.g. the test suite at https://github.com/cucumber/tag-expressions/blob/main/testdata/parsing.yml):
- `and` and `or` are left-associative (the associativity does not change their semantics due to commutativity)
- `or` has the lowest precedence, `and` has a medium precedence, and `not` has highest precedence.

Additionaly, parentheses should allow whitespace.

Fixes #51