### PR TITLE
fix: allow and/but as first step of a scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,13 @@ All user visible changes to `gherkin` crate will be documented in this file. Thi
 
 - Fixed precedence of operations in tag expressions to align with upstream. ([#52], [#51])
 
+### Changed
+
+- Allowed `And`-like and `But`-like keywords at the beginning of `Scenario`, automatically considering them as `Given`-type steps. ([#53])
+
 [#51]: https://github.com/cucumber-rs/gherkin/issues/51
 [#52]: https://github.com/cucumber-rs/gherkin/pull/52
+[#53]: https://github.com/cucumber-rs/gherkin/pull/53
 
 
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -780,9 +780,10 @@ Rule: rule
     #[test]
     fn and_as_first_step() {
         let env = GherkinEnv::default();
-        let input = r#"Feature: First step with And
-Scenario: And as first step
-  And a step
+        let input = r#"
+Feature: First step with And
+  Scenario: And as first step
+    And a step
 "#;
         let feature = gherkin_parser::feature(input, &env).unwrap();
         assert_eq!(feature.scenarios.len(), 1);
@@ -793,8 +794,9 @@ Scenario: And as first step
     #[test]
     fn but_as_first_step() {
         let env = GherkinEnv::default();
-        let input = r#"Feature: First step with But
-Scenario: But as first step
+        let input = r#"
+Feature: First step with But
+  Scenario: But as first step
     But a step
 "#;
         let feature = gherkin_parser::feature(input, &env).unwrap();
@@ -806,8 +808,9 @@ Scenario: But as first step
     #[test]
     fn scenario_description() {
         let env = GherkinEnv::default();
-        let input = r#"Feature: First step with Besides
-Scenario: Besides as first step
+        let input = r#"
+Feature: First step with Besides
+  Scenario: Besides as first step
     Besides a step
 "#;
         let feature = gherkin_parser::feature(input, &env).unwrap();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -315,41 +315,31 @@ pub(crate) rule step() -> Step
     }
     / pa:position!() k:keyword((env.keywords().and)) _ n:not_nl() pb:position!() _ nl_eof() _
       d:docstring()? t:table()?
-    {?
-        match env.last_step() {
-            Some(v) => {
-                Ok(Step::builder().ty(v)
-                    .keyword(k.to_string())
-                    .value(n.trim_end().to_string())
-                    .table(t)
-                    .docstring(d)
-                    .span(Span { start: pa, end: pb })
-                    .position(env.position(pa))
-                    .build())
-            }
-            None => {
-                Err("given, when or then")
-            }
-        }
+    {
+        let ty = env.last_step().unwrap_or(StepType::Given);
+        env.set_last_step(ty);
+        Step::builder().ty(ty)
+            .keyword(k.to_string())
+            .value(n.trim_end().to_string())
+            .table(t)
+            .docstring(d)
+            .span(Span { start: pa, end: pb })
+            .position(env.position(pa))
+            .build()
     }
     / pa:position!() k:keyword((env.keywords().but)) _ n:not_nl() pb:position!() _ nl_eof() _
       d:docstring()? t:table()?
-    {?
-        match env.last_step() {
-            Some(v) => {
-                Ok(Step::builder().ty(v)
-                    .keyword(k.to_string())
-                    .value(n.trim_end().to_string())
-                    .table(t)
-                    .docstring(d)
-                    .span(Span { start: pa, end: pb })
-                    .position(env.position(pa))
-                    .build())
-            }
-            None => {
-                Err("given, when or then")
-            }
-        }
+    {
+        let ty = env.last_step().unwrap_or(StepType::Given);
+        env.set_last_step(ty);
+        Step::builder().ty(ty)
+            .keyword(k.to_string())
+            .value(n.trim_end().to_string())
+            .table(t)
+            .docstring(d)
+            .span(Span { start: pa, end: pb })
+            .position(env.position(pa))
+            .build()
     }
 
 pub(crate) rule steps() -> Vec<Step>
@@ -783,6 +773,44 @@ Rule: rule
         assert_eq!(feature.rules[1].position.line, 32);
         assert_eq!(feature.rules[1].scenarios[0].position.line, 34);
         assert_eq!(feature.rules[1].scenarios[0].steps[0].position.line, 35);
+    }
+
+    #[test]
+    fn and_as_first_step() {
+        let env = GherkinEnv::default();
+        let input = r#"Feature: First step with And
+Scenario: And as first step
+  And a step
+"#;
+        let feature = gherkin_parser::feature(input, &env).unwrap();
+        assert_eq!(feature.scenarios.len(), 1);
+        assert_eq!(feature.scenarios[0].steps.len(), 1);
+        assert_eq!(feature.scenarios[0].steps[0].ty, StepType::Given);
+    }
+
+    #[test]
+    fn but_as_first_step() {
+        let env = GherkinEnv::default();
+        let input = r#"Feature: First step with But
+Scenario: But as first step
+    But a step
+"#;
+        let feature = gherkin_parser::feature(input, &env).unwrap();
+        assert_eq!(feature.scenarios.len(), 1);
+        assert_eq!(feature.scenarios[0].steps.len(), 1);
+        assert_eq!(feature.scenarios[0].steps[0].ty, StepType::Given);
+    }
+
+    #[test]
+    fn scenario_description() {
+        let env = GherkinEnv::default();
+        let input = r#"Feature: First step with Besides
+Scenario: Besides as first step
+    Besides a step
+"#;
+        let feature = gherkin_parser::feature(input, &env).unwrap();
+        assert_eq!(feature.scenarios.len(), 1);
+        assert_eq!(feature.scenarios[0].steps.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
For Scenarios that have a Background, it is common that they start with `And` and not necessarily a `Given`, `When` or `Then`.